### PR TITLE
feat: 대시보드 기능 추가

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,112 @@
+# EXP-MISSION-Shoppingmall
+
+# 프로젝트 디렉토리 구조
+src/main/java/solid/backend
+
+- admin : 관리자 페이지
+    - product : 물품관리
+- entity : 엔티티
+    - Auth : 권한
+    - Member : 회원
+    - Travel : 여행상품
+    - Product : 물품
+    - Orders : 주문
+    - OrderTravel : 여행 주문
+    - OrderProduct : 물품 주문
+    - payment : 결제수단
+    - Basket : 장바구니
+    - Review : 리뷰
+    - CompoundKey : 조합키
+
+
+### 대시보드 : admin/dashboard
+- controller(컨트롤러)
+    - DashboardController.java
+- dto(객체정보)
+    - DashboardCategoryStatsDto.java
+    - DashboardMonthlyTxDto.java
+    - DashboardProductStatsDto.java
+    - DashboardWeeklySalesAmtDto.java
+- repository(jpa)
+    - DashboardQueryRepository.java
+- service(비즈니스 로직)
+    - DashboardService.java
+    - DashboardServiceImpl.java
+
+### 대시보드 조회 목록
+[이번달 거래현황]  
+HTTP method : GET  
+HTTP request URL : /admin/dashboard/getDashboardMonthlyTxDto  
+param : x  
+return : DashboardMonthlyTxDto  
+
+테이블에서 데이터 조회
+- travel : 여행 상품  
+- product : 물품  
+- orders : 주문  
+- order_travel : 여행 주문  
+- order_product : 물품 주문  
+
+이번달 날짜 조건 처리
+- 오늘 날짜 (예: 2025-06-12) -> firstDayOfMonth : 2025-06-01, firstDayOfNextMonth : 2025-07-01
+- LocalDate today = LocalDate.now();
+- LocalDate firstDayOfMonth = today.withDayOfMonth(1);
+- LocalDate firstDayOfNextMonth = firstDayOfMonth.plusMonths(1);
+- 쿼리 : .where(orders.orderDt.goe(firstDayOfMonth).and(orders.orderDt.lt(firstDayOfNextMonth)))
+
+조회 조건 및 테이블 조인 관계
+- 총 거래 수 : orderProductAmount + orderTravelAmount  
+- 거래 취소 수 : order_state = 1인 주문들의 orderProductAmount + orderTravelAmount  
+- 거래 확정 수 : order_state = 1인 주문들을 제외한 orderProductAmount + orderTravelAmount  
+- 총 매출 금액 : order_state = 1인 주문들을 제외한 orderProductAmount * productPrice + orderTravelAmount * travelPrice  
+
+[현재 상품 현황]  
+HTTP method : GET  
+HTTP request URL : /admin/dashboard/getDashboardProductStatsDto  
+param : x  
+return : DashboardProductStatsDto
+
+테이블에서 데이터 조회
+- travel : 여행 상품  
+- product : 물품  
+
+조회 조건 및 테이블 조인 관계
+- 총 상품, 물품 수 : travels + products
+- 품절 상품, 물품 수 : travel_sold = true인 travels + product_sold = true인 products
+
+[거래 물품 카테고리 통계]  
+HTTP method : GET  
+HTTP request URL : /admin/product/getDashboardCategoryStatsDto  
+param : x
+return : List< DashboardCategoryStatsDto >
+
+테이블에서 데이터 조회
+- orders : 주문
+- product : 물품
+- order_product : 물품 주문
+
+조회 조건 및 테이블 조인 관계
+- 모든 제품별 주문 수량 합계 조회 : products + orders + order_product
+
+[이번 주 거래 금액 통계]  
+HTTP method : GET  
+HTTP request URL : /admin/product/getDashboardWeeklySalesAmtDto  
+param : x
+return : List< DashboardWeeklySalesAmtDto >
+
+테이블에서 데이터 조회
+- orders : 주문
+- travel : 여행 상품
+- product : 물품
+- order_product : 물품 주문
+- order_travel : 여행 주문
+
+이번주 날짜 조건 처리
+- 오늘 날짜 (예: 2025-06-13) -> firstDayOfMonth : 이번 주 월요일(2025-06-09), firstDayOfNextMonth : 2025-06-15(이번 주 일요일)
+- LocalDate today = LocalDate.now();
+- LocalDate monday = today.with(DayOfWeek.MONDAY);
+- LocalDate sunday = monday.plusDays(6);
+- 쿼리 : .where(orders.orderDt.between(monday, sunday).and(orders.orderState.ne(1)))
+
+조회 조건 및 테이블 조인 관계
+- 여행상품, 물품 기준 일별 총 금액 : order_state = 1인 주문을 제외한 orderProductAmount * productPrice + orderTravelAmount * travelPrice

--- a/backend/src/main/java/solid/backend/admin/dashboard/comtroller/DashboardController.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/comtroller/DashboardController.java
@@ -1,0 +1,62 @@
+package solid.backend.admin.dashboard.comtroller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import solid.backend.admin.dashboard.dto.DashboardCategoryStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardMonthlyTxDto;
+import solid.backend.admin.dashboard.dto.DashboardProductStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardWeeklySalesAmtDto;
+import solid.backend.admin.dashboard.service.DashboardService;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    /**
+     * 설명 : 이번달 거래 현황
+     * @return DashboardMonthlyTxDto
+     */
+    @ResponseBody
+    @GetMapping("/getDashboardMonthlyTxDto")
+    public DashboardMonthlyTxDto getDashboardMonthlyTxDto() {
+        return dashboardService.getDashboardMonthlyTxDto();
+    }
+
+    /**
+     * 설명 : 현재 상품 현황
+     * @return DashboardProductStatsDto
+     */
+    @ResponseBody
+    @GetMapping("/getDashboardProductStatsDto")
+    public DashboardProductStatsDto getDashboardProductStatsDto() {
+        return dashboardService.getDashboardProductStatsDto();
+    }
+
+    /**
+     * 설명 : 거래 카테고리 통계(물품)
+     * @return DashboardCategoryStatsDto
+     */
+    @ResponseBody
+    @GetMapping("/getDashboardCategoryStatsDto")
+    public List<DashboardCategoryStatsDto> getDashboardCategoryStatsDto() {
+        return dashboardService.getDashboardCategoryStatsDto();
+    }
+
+    /**
+     * 설명 : 이번 주 거래 금액 통계
+     * @return List<DashboardWeeklySalesAmtDto>
+     */
+    @ResponseBody
+    @GetMapping("/getDashboardWeeklySalesAmtDto")
+    public List<DashboardWeeklySalesAmtDto> getDashboardWeeklySalesAmtDto() {
+        return dashboardService.getDashboardWeeklySalesAmtDto();
+    }
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardCategoryStatsDto.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardCategoryStatsDto.java
@@ -1,0 +1,12 @@
+package solid.backend.admin.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DashboardCategoryStatsDto {
+
+    private String categoryName;
+    private Long totalAmount;
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardMonthlyTxDto.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardMonthlyTxDto.java
@@ -1,0 +1,14 @@
+package solid.backend.admin.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+public class DashboardMonthlyTxDto {
+    private Long totalTx;
+    private Long cancelTx;
+    private Long completeTx;
+    private Long totalAmt;
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardProductStatsDto.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardProductStatsDto.java
@@ -1,0 +1,12 @@
+package solid.backend.admin.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DashboardProductStatsDto {
+
+    private Long totalTravelProducts;
+    private Long soldOutTravelProducts;
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardWeeklySalesAmtDto.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/dto/DashboardWeeklySalesAmtDto.java
@@ -1,0 +1,14 @@
+package solid.backend.admin.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+public class DashboardWeeklySalesAmtDto {
+
+    private LocalDate date;
+    private Long amount;
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/repository/DashboardQueryRepository.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/repository/DashboardQueryRepository.java
@@ -1,0 +1,277 @@
+package solid.backend.admin.dashboard.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import solid.backend.admin.dashboard.dto.DashboardCategoryStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardMonthlyTxDto;
+import solid.backend.admin.dashboard.dto.DashboardProductStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardWeeklySalesAmtDto;
+import solid.backend.entity.QOrders;
+import solid.backend.entity.QOrderProduct;
+import solid.backend.entity.QOrderTravel;
+import solid.backend.entity.QProduct;
+import solid.backend.entity.QTravel;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+public class DashboardQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public DashboardQueryRepository(EntityManager em) {
+        this.query = new JPAQueryFactory(em);
+    }
+
+    /**
+     * 설명 : 이번달 거래 현황
+     * @return DashboardMonthlyTxDto
+     */
+    public DashboardMonthlyTxDto getDashboardMonthlyTxDto() {
+        QOrders orders = QOrders.orders;
+        QProduct products = QProduct.product;
+        QTravel travels = QTravel.travel;
+        QOrderProduct orderProducts = QOrderProduct.orderProduct;
+        QOrderTravel orderTravels = QOrderTravel.orderTravel;
+
+        // 오늘 날짜 (예: 2025-06-12) -> firstDayOfMonth : 2025-06-01, firstDayOfNextMonth : 2025-07-01
+        LocalDate today = LocalDate.now();
+        LocalDate firstDayOfMonth = today.withDayOfMonth(1);
+        LocalDate firstDayOfNextMonth = firstDayOfMonth.plusMonths(1);
+
+        // 총 거래 수(orderProductAmount + orderTravelAmount)
+        Long orderProductTx = query
+                .select(orderProducts.orderProductAmount.sum().longValue())
+                .from(orderProducts)
+                .join(orderProducts.order, orders)
+                .where(orders.orderDt.goe(firstDayOfMonth).and(orders.orderDt.lt(firstDayOfNextMonth)))
+                .fetchOne();
+
+        Long orderTravelTx = query
+                .select(orderTravels.orderTravelAmount.sum().longValue())
+                .from(orderTravels)
+                .join(orderTravels.order, orders)
+                .where(orders.orderDt.goe(firstDayOfMonth).and(orders.orderDt.lt(firstDayOfNextMonth)))
+                .fetchOne();
+
+        Long totalTx = (orderProductTx != null ? orderProductTx : 0L) + (orderTravelTx != null ? orderTravelTx : 0L);
+
+        // 거래 취소 수(order_state = 1인 주문들의 orderProductAmount + orderTravelAmount)
+        Long cancelProductTx = query
+                .select(orderProducts.orderProductAmount.sum().longValue())
+                .from(orderProducts)
+                .join(orderProducts.order, orders)
+                .where(
+                        orders.orderState.eq(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long cancelTravelTx = query
+                .select(orderTravels.orderTravelAmount.sum().longValue())
+                .from(orderTravels)
+                .join(orderTravels.order, orders)
+                .where(
+                        orders.orderState.eq(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long cancelTx = (cancelProductTx != null ? cancelProductTx : 0L) + (cancelTravelTx != null ? cancelTravelTx : 0L);
+
+        // 거래 확정 수(order_state = 1인 주문들을 제외한 orderProductAmount + orderTravelAmount)
+        Long completeProductTx = query
+                .select(orderProducts.orderProductAmount.sum().longValue())
+                .from(orderProducts)
+                .join(orderProducts.order, orders)
+                .where(
+                        orders.orderState.ne(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long completeTravelTx = query
+                .select(orderTravels.orderTravelAmount.sum().longValue())
+                .from(orderTravels)
+                .join(orderTravels.order, orders)
+                .where(
+                        orders.orderState.ne(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long completeTx = (completeProductTx != null ? completeProductTx : 0L) + (completeTravelTx != null ? completeTravelTx : 0L);
+
+        // 총 매출 금액(order_state = 1인 주문들을 제외한 orderProductAmount * productPrice + orderTravelAmount * travelPrice)
+        Long productAmt = query
+                .select(orderProducts.orderProductAmount.multiply(products.productPrice).sum().longValue())
+                .from(orderProducts)
+                .join(orderProducts.product, products)
+                .join(orderProducts.order, orders)
+                .where(
+                        orders.orderState.ne(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long travelAmt = query
+                .select(orderTravels.orderTravelAmount.multiply(travels.travelPrice).sum().longValue())
+                .from(orderTravels)
+                .join(orderTravels.travel, travels)
+                .join(orderTravels.order, orders)
+                .where(
+                        orders.orderState.ne(1)
+                                .and(orders.orderDt.goe(firstDayOfMonth))
+                                .and(orders.orderDt.lt(firstDayOfNextMonth))
+                )
+                .fetchOne();
+
+        Long totalAmt = (productAmt != null ? productAmt : 0L) + (travelAmt != null ? travelAmt : 0L);
+
+        return new DashboardMonthlyTxDto(totalTx, cancelTx, completeTx, totalAmt);
+    }
+
+    /**
+     * 설명 : 현재 상품 현황
+     * @return DashboardMonthlyTxDto
+     */
+    public DashboardProductStatsDto getDashboardProductStatsDto() {
+
+        QProduct products = QProduct.product;
+        QTravel travels = QTravel.travel;
+
+        // 총 상품, 물품 수(travels + products)
+        Long totalTravel = query
+                .select(travels.count())
+                .from(travels)
+                .fetchOne();
+
+        Long totalProduct = query
+                .select(products.count())
+                .from(products)
+                .fetchOne();
+
+        Long totalTravelProducts = (totalTravel != null ? totalTravel : 0L) + (totalProduct != null ? totalProduct : 0L);
+
+        // 품절 상품, 물품 수(travel_sold = true인 travels + product_sold = true인 products)
+        Long soldOutTravel = query
+                .select(travels.count())
+                .from(travels)
+                .where(travels.travelSold.eq(true))
+                .fetchOne();
+
+        Long soldOutProduct = query
+                .select(products.count())
+                .from(products)
+                .where(products.productSold.eq(true))
+                .fetchOne();
+
+        Long soldOutTravelProducts = (soldOutTravel != null ? soldOutTravel : 0L) + (soldOutProduct != null ? soldOutProduct : 0L);
+
+        return new DashboardProductStatsDto(totalTravelProducts, soldOutTravelProducts);
+    }
+
+    /**
+     * 설명 : 거래 카테고리 통계(물품)
+     * @return List<DashboardCategoryStatsDto>
+     */
+    public List<DashboardCategoryStatsDto> getDashboardCategoryStatsDto() {
+
+        QOrders orders = QOrders.orders;
+        QProduct products = QProduct.product;
+        QOrderProduct orderProducts = QOrderProduct.orderProduct;
+
+        //모든 제품별 주문 수량 합계 조회 (주문취소 제외, 주문 없으면 0 포함)
+        return query
+                .select(Projections.constructor(DashboardCategoryStatsDto.class,
+                        products.productName,
+                        orderProducts.orderProductAmount.sum().longValue().coalesce(0L)
+                ))
+                .from(products)
+                .leftJoin(orderProducts)
+                .on(orderProducts.product.eq(products))
+                .leftJoin(orderProducts.order, orders)
+                .on(orders.orderState.ne(1))
+                .groupBy(products.productName)
+                .fetch();
+    }
+
+    /**
+     * 설명 : 이번 주 거래 금액 통계
+     * @return DashboardWeeklySalesAmtDto
+     */
+    public List<DashboardWeeklySalesAmtDto> getDashboardWeeklySalesAmtDto() {
+        QOrders orders = QOrders.orders;
+        QProduct products = QProduct.product;
+        QTravel travels = QTravel.travel;
+        QOrderProduct orderProducts = QOrderProduct.orderProduct;
+        QOrderTravel orderTravels = QOrderTravel.orderTravel;
+
+        // 오늘 날짜 (예: 2025-06-13) -> firstDayOfMonth : 이번 주 월요일(2025-06-09), firstDayOfNextMonth : 2025-06-15(이번 주 일요일)
+        LocalDate today = LocalDate.now();
+        LocalDate monday = today.with(DayOfWeek.MONDAY);
+        LocalDate sunday = monday.plusDays(6);
+
+        // 여행상품, 물품 기준 일별 총 금액
+        List<Tuple> productStats = query
+                .select(orders.orderDt, orderProducts.orderProductAmount.multiply(products.productPrice).sum().longValue())
+                .from(orderProducts)
+                .join(orderProducts.order, orders)
+                .join(orderProducts.product, products)
+                .where(orders.orderDt.between(monday, sunday).and(orders.orderState.ne(1)))
+                .groupBy(orders.orderDt)
+                .fetch();
+
+        List<Tuple> travelStats = query
+                .select(orders.orderDt, orderTravels.orderTravelAmount.multiply(travels.travelPrice).sum().longValue())
+                .from(orderTravels)
+                .join(orderTravels.order, orders)
+                .join(orderTravels.travel, travels)
+                .where(orders.orderDt.between(monday, sunday).and(orders.orderState.ne(1)))
+                .groupBy(orders.orderDt)
+                .fetch();
+
+        // 날짜별로 금액을 합쳐서 맵으로 구성
+        Map<LocalDate, Long> dailyTotalMap = new HashMap<>();
+
+        for (Tuple t : productStats) {
+            LocalDate date = t.get(0, LocalDate.class);
+            Long amount = t.get(1, Long.class);
+            dailyTotalMap.put(date, amount);
+        }
+
+        for (Tuple t : travelStats) {
+            LocalDate date = t.get(0, LocalDate.class);
+            Long amount = Optional.ofNullable(t.get(1, Long.class)).orElse(0L);
+            if (dailyTotalMap.containsKey(date)) {
+                dailyTotalMap.put(date, dailyTotalMap.get(date) + amount);
+            } else {
+                dailyTotalMap.put(date, amount);
+            }
+        }
+
+        // 일자별 데이터 생성 (값 없으면 0 처리)
+        List<DashboardWeeklySalesAmtDto> result = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = monday.plusDays(i);
+            result.add(new DashboardWeeklySalesAmtDto(date, dailyTotalMap.getOrDefault(date, 0L)));
+        }
+
+        return result;
+    }
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/service/DashboardService.java
@@ -1,0 +1,35 @@
+package solid.backend.admin.dashboard.service;
+
+import solid.backend.admin.dashboard.dto.DashboardCategoryStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardMonthlyTxDto;
+import solid.backend.admin.dashboard.dto.DashboardProductStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardWeeklySalesAmtDto;
+
+import java.util.List;
+
+public interface DashboardService {
+
+    /**
+     * 설명 : 이번달 거래 현황
+     * @return DashboardMonthlyTxDto
+     */
+    DashboardMonthlyTxDto getDashboardMonthlyTxDto();
+
+    /**
+     * 설명 : 현재 상품 현황
+     * @return DashboardProductStatsDto
+     */
+    DashboardProductStatsDto getDashboardProductStatsDto();
+
+    /**
+     * 설명 : 거래 카테고리 통계(물품)
+     * @return List<DashboardCategoryStatsDto>
+     */
+    List<DashboardCategoryStatsDto> getDashboardCategoryStatsDto();
+
+    /**
+     * 설명 : 이번 주 거래 금액 통계
+     * @return List<DashboardWeeklySalesAmtDto>
+     */
+    List<DashboardWeeklySalesAmtDto> getDashboardWeeklySalesAmtDto();
+}

--- a/backend/src/main/java/solid/backend/admin/dashboard/service/DashboardServiceImpl.java
+++ b/backend/src/main/java/solid/backend/admin/dashboard/service/DashboardServiceImpl.java
@@ -1,0 +1,54 @@
+package solid.backend.admin.dashboard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import solid.backend.admin.dashboard.dto.DashboardCategoryStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardMonthlyTxDto;
+import solid.backend.admin.dashboard.dto.DashboardProductStatsDto;
+import solid.backend.admin.dashboard.dto.DashboardWeeklySalesAmtDto;
+import solid.backend.admin.dashboard.repository.DashboardQueryRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService {
+
+    private final DashboardQueryRepository dashboardQueryRepository;
+
+    /**
+     * 설명 : 이번달 거래 현황
+     * @return DashboardMonthlyTxDto
+     */
+    @Override
+    public DashboardMonthlyTxDto getDashboardMonthlyTxDto() {
+        return dashboardQueryRepository.getDashboardMonthlyTxDto();
+    }
+
+    /**
+     * 설명 : 이번달 거래 현황
+     * @return DashboardMonthlyTxDto
+     */
+    @Override
+    public DashboardProductStatsDto getDashboardProductStatsDto() {
+        return dashboardQueryRepository.getDashboardProductStatsDto();
+    }
+
+    /**
+     * 설명 : 거래 카테고리 통계(물품)
+     * @return List<DashboardCategoryStatsDto>
+     */
+    @Override
+    public List<DashboardCategoryStatsDto> getDashboardCategoryStatsDto() {
+        return dashboardQueryRepository.getDashboardCategoryStatsDto();
+    }
+
+    /**
+     * 설명 : 이번 주 거래 금액 통계
+     * @return List<DashboardWeeklySalesAmtDto>
+     */
+    @Override
+    public List<DashboardWeeklySalesAmtDto> getDashboardWeeklySalesAmtDto() {
+        return dashboardQueryRepository.getDashboardWeeklySalesAmtDto();
+    }
+}


### PR DESCRIPTION
## 변경 사항 설명
사용 테이블
- travel : 여행 상품
- product : 물품
- orders : 주문
- order_travel : 여행 주문
- order_product : 물품 주문

각 4가지 요청에 대한 기능 만들것

[이번달 거래현황]
HTTP method : GET
HTTP request URL : /admin/dashboard/getDashboardMonthlyTxDto
param : x
return : DashboardMonthlyTxDto

[현재 상품 현황]
HTTP method : GET
HTTP request URL : /admin/dashboard/getDashboardProductStatsDto
param : x
return : DashboardProductStatsDto

[거래 물품 카테고리 통계]
HTTP method : GET
HTTP request URL : /admin/product/getDashboardCategoryStatsDto
param : x
return : List< DashboardCategoryStatsDto >

[이번 주 거래 금액 통계]
HTTP method : GET
HTTP request URL : /admin/product/getDashboardWeeklySalesAmtDto
param : x
return : List< DashboardWeeklySalesAmtDto >

## 관련 이슈
#12 

## 체크리스트
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)

## 리뷰어를 위한 참고사항
테스트는 Postman 사용