### PR TITLE
feat: refresh token을 이용한 access token 재발급

### DIFF
--- a/backend/src/main/java/solid/backend/Jwt/JwtController.java
+++ b/backend/src/main/java/solid/backend/Jwt/JwtController.java
@@ -1,0 +1,51 @@
+package solid.backend.Jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/token")
+public class JwtController {
+
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 설명: refresh token을 활용하여 access token 재발급
+     * @param request
+     * @return ResponseEntity
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return ResponseEntity.status(401).body("세션이 존재하지 않습니다.");
+        }
+
+        String refreshToken = (String) session.getAttribute("refreshToken");
+
+        if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+            return ResponseEntity.status(401).body("Refresh Token이 유효하지 않습니다. 다시 로그인하세요.");
+        }
+
+        String memberId = jwtUtil.getMemberId(refreshToken);
+        String authId = jwtUtil.getAuthId(refreshToken);
+
+        String newAccessToken = jwtUtil.createAccessToken(
+                AccessToken.builder()
+                        .memberId(memberId)
+                        .authId(authId)
+                        .build()
+        );
+
+        return ResponseEntity.ok(newAccessToken);
+    }
+}

--- a/backend/src/main/java/solid/backend/Jwt/JwtUtil.java
+++ b/backend/src/main/java/solid/backend/Jwt/JwtUtil.java
@@ -83,6 +83,7 @@ public class JwtUtil {
     public String createRefresh(AccessToken accessToken, long refreshTokenExpTime) {
         Claims claims = Jwts.claims();
         claims.put("memberId", accessToken.getMemberId());
+        claims.put("authId", accessToken.getAuthId());
         claims.put("type", "refresh");
 
         ZonedDateTime now = ZonedDateTime.now();
@@ -149,6 +150,19 @@ public class JwtUtil {
                     .getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
+        }
+    }
+
+    /**
+     * 설명: jwt 토큰에서 type을 꺼내서 access token, refresh token 구분
+     * @param token
+     * @return String (Claims)
+     */
+    public String getTokenType(String token) {
+        try {
+            return parseClaims(token).get("type", String.class);
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/backend/src/main/java/solid/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/solid/backend/config/SecurityConfig.java
@@ -20,15 +20,16 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         //.requestMatchers("/**").permitAll()  // 테스트를 위해 admin, main 인증 없이 허용 (테스트 완료 후 제거)
-                        .requestMatchers("/main/sign/**", "/main/home/**").permitAll() //메인 홈, 로그인 관련 페이지는 모두 접근 허용
-                        .requestMatchers("/admin/member/**").hasAuthority("ADMIN") //관리자 권한인 경우 admin api 호출가능
+                        .requestMatchers("/main/sign/**", "/home/**").permitAll() // 메인 홈, 로그인 관련 페이지는 모두 접근 허용
+                        .requestMatchers("/admin/member/**").hasAuthority("ADMIN") // 관리자 권한인 경우 admin api 호출가능
                         .requestMatchers("/admin/member/travel/**", "/admin/member/product/**").hasAuthority("MANAGER")
+                        .requestMatchers("/token/refresh").permitAll() // 토큰 재발급 api
+                        .requestMatchers("/solid/**").permitAll() // 상품 이미지 파일 경로도 허용해줘야됨.
                         //.requestMatchers("/main/mypage/member").hasAuthority("USER") // 사용자 권한 예시
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFiler, UsernamePasswordAuthenticationFilter.class)
-                .formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> {});
+                .formLogin(form -> form.disable());
 
         return http.build();
     }

--- a/backend/src/main/java/solid/backend/main/sign/controller/SignController.java
+++ b/backend/src/main/java/solid/backend/main/sign/controller/SignController.java
@@ -1,5 +1,6 @@
 package solid.backend.main.sign.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,9 +52,9 @@ public class SignController {
      * @return ResponseEntity<String>
      */
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody SignInDto signInDto) {
+    public ResponseEntity<String> login(@RequestBody SignInDto signInDto, HttpServletRequest request) {
         try {
-            String token = signService.login(signInDto);
+            String token = signService.login(signInDto, request);
             return ResponseEntity.ok(token);
         } catch (UsernameNotFoundException | BadCredentialsException e) {
             return ResponseEntity

--- a/backend/src/main/java/solid/backend/main/sign/service/SignService.java
+++ b/backend/src/main/java/solid/backend/main/sign/service/SignService.java
@@ -1,5 +1,6 @@
 package solid.backend.main.sign.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import solid.backend.main.sign.dto.*;
 
 
@@ -19,8 +20,9 @@ public interface SignService {
     /**
      * 설명: 로그인
      * @param signInDto
+     * @param request
      */
-    String login(SignInDto signInDto);
+    String login(SignInDto signInDto, HttpServletRequest request);
 
     /**
      * 설명: 아이디 찾기

--- a/backend/src/main/java/solid/backend/main/sign/service/SignServiceImpl.java
+++ b/backend/src/main/java/solid/backend/main/sign/service/SignServiceImpl.java
@@ -1,6 +1,8 @@
 package solid.backend.main.sign.service;
 
 import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -59,10 +61,11 @@ public class SignServiceImpl implements SignService {
     /**
      * 설명: 로그인 시 토큰 발급
      * @param signInDto
+     * @param request
      * @return token
      */
     @Override
-    public String login(SignInDto signInDto) {
+    public String login(SignInDto signInDto, HttpServletRequest request) {
         // 1. 사용자 조회
         Optional<Member> optionalMember = signRepository.findById(signInDto.getMemberId());
         if (optionalMember.isEmpty()) {
@@ -87,6 +90,14 @@ public class SignServiceImpl implements SignService {
 
         // refreshToken은 백엔드에서 저장 필요.
         String refreshToken = jwtUtil.createRefreshToken(dto);
+
+        System.out.println("accessToken: " + accessToken);
+        System.out.println("refreshToken: " + refreshToken);
+
+
+        // 세션에 refreshToken 저장
+        HttpSession session = request.getSession(true);
+        session.setAttribute("refreshToken", refreshToken);
 
         // 5. access token 반환
         return accessToken;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,3 +14,7 @@ spring.servlet.multipart.max-request-size=10MB
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 spring.config.import=application-secret.properties
+
+#JWT log
+logging.level.root=INFO
+logging.level.solid.backend.Jwt=DEBUG


### PR DESCRIPTION
## 변경 사항 설명
Access 토큰 만료 시 재발급 api 생성

[토큰 재발급]
HTTP method : POST
HTTP request URL : /token/refresh
param : request
return : ResponseEntity

## 관련 이슈
#131 

## 체크리스트
- [ ] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
- 이슈 131 참고

## 리뷰어를 위한 참고사항
- postman 테스트
