### PR TITLE
feat: refresh token 세션 삭제

### DIFF
--- a/backend/src/main/java/solid/backend/Jwt/JwtController.java
+++ b/backend/src/main/java/solid/backend/Jwt/JwtController.java
@@ -33,6 +33,7 @@ public class JwtController {
         String refreshToken = (String) session.getAttribute("refreshToken");
 
         if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+            session.removeAttribute("refreshToken"); // 토큰 삭제
             return ResponseEntity.status(401).body("Refresh Token이 유효하지 않습니다. 다시 로그인하세요.");
         }
 

--- a/backend/src/main/java/solid/backend/Jwt/README.md
+++ b/backend/src/main/java/solid/backend/Jwt/README.md
@@ -1,0 +1,12 @@
+### JWT 토큰 관리
+- AccessToken.java : 토큰에 저장된 정보
+- JwtController.java : 토큰 재발급 컨트롤러
+- JwtFilter.java : 토큰 유효성 검사
+- JwtUtil.java : 토큰 관리
+
+### API 목록
+[refresh token을 사용하여 Access token 재발급]
+- HTTP method : POST
+- HTTP request URL : /token/refresh
+- param : request
+- return : ResponseEntity

--- a/backend/src/main/java/solid/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/solid/backend/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
                         .requestMatchers("/admin/member/travel/**", "/admin/member/product/**").hasAuthority("MANAGER")
                         .requestMatchers("/token/refresh").permitAll() // 토큰 재발급 api
                         .requestMatchers("/solid/**").permitAll() // 상품 이미지 파일 경로도 허용해줘야됨.
+                        .requestMatchers("mypage/**").hasAuthority("USER")
                         //.requestMatchers("/main/mypage/member").hasAuthority("USER") // 사용자 권한 예시
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/solid/backend/main/sign/README.md
+++ b/backend/src/main/java/solid/backend/main/sign/README.md
@@ -5,7 +5,7 @@
   - SignCheckIdEmailDto.java
   - SignFindIdDto.java
   - SignInDto.java
-  - SignMemberInfoDto.java
+  - SignUpCheckEmailDto.java
   - SignUpCheckIdDto.java
   - SignUpdPwDto.java
   - SignUpDto.java
@@ -26,6 +26,12 @@
 - HTTP method : POST
 - HTTP request URL : /main/sign/checkId
 - param : signInCheckIdDto
+- return : ResponseEntity<Boolean> (아이디가 있으면 true, 없으면 false)
+
+[회원가입 이메일 중복 확인]
+- HTTP method : POST
+- HTTP request URL : /main/sign/checkEmail
+- param : signInCheckEmailDto
 - return : ResponseEntity<Boolean> (아이디가 있으면 true, 없으면 false)
 
 [로그인]
@@ -50,4 +56,10 @@
 - HTTP method : POST
 - HTTP request URL : /main/sign/updPw
 - param : signUpdPwDto
+- return : ResponseEntity<String>
+
+[로그아웃]
+- HTTP method : POST
+- HTTP request URL : /main/sign/logout
+- param : request
 - return : ResponseEntity<String>

--- a/backend/src/main/java/solid/backend/main/sign/controller/SignController.java
+++ b/backend/src/main/java/solid/backend/main/sign/controller/SignController.java
@@ -1,6 +1,7 @@
 package solid.backend.main.sign.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -127,5 +128,19 @@ public class SignController {
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("FAIL");
         }
+    }
+
+    /**
+     * 설명: 로그아웃 (세션에 저장된 refresh token 삭제)
+     * @param request
+     * @return ResponseEntity<String>
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute("refreshToken");
+        }
+        return ResponseEntity.ok("로그아웃되었습니다.");
     }
 }


### PR DESCRIPTION
## 변경 사항 설명
백엔드 세션에 저장된 토큰이 만료되었을 때 삭제 필요 

1. 재발급 컨트롤러에서 만료된 것을 확인했을 때 세션에서 삭제

2. 로그아웃 시 세션에서 토큰 삭제
[로그아웃]
- HTTP method : POST
- HTTP request URL : /main/sign/logout
- param : request
- return : ResponseEntity<String>

## 관련 이슈
#153 

## 체크리스트
- [ ] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
1. 로그인
<img width="738" alt="스크린샷 2025-07-02 오전 2 01 26" src="https://github.com/user-attachments/assets/bf0e3c0f-b6db-4958-b1e9-d6aeac24df06" />

2. 토큰 재발급 성공
<img width="734" alt="스크린샷 2025-07-02 오전 2 02 53" src="https://github.com/user-attachments/assets/4aebf2a9-13a0-49d3-921c-ecf88def1cc7" />


3. 토큰 재발급 실패 (로그아웃 & 토큰 만료)
<img width="721" alt="스크린샷 2025-07-02 오전 2 01 05" src="https://github.com/user-attachments/assets/76780b61-568b-4281-b5df-bd035222633e" />

4. 로그아웃
<img width="729" alt="스크린샷 2025-07-02 오전 2 03 20" src="https://github.com/user-attachments/assets/4e446a81-bfb2-46eb-8082-340e9aff967c" />


## 리뷰어를 위한 참고사항
postman 테스트