### PR TITLE
refactor: 토큰 재발급 공통 로직 분리

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
-import { authApi } from "./login/authApi";
-import { isLoggedIn } from "../utils/auth";
+import { isLoggedIn, refreshNewToken } from "../utils/auth";
 
 // axios 기본 설정
 const api = axios.create({
@@ -36,13 +35,11 @@ api.interceptors.response.use(
     if (!isLoggedIn() && !error.config._retry) {
       error.config._retry = true;
 
-      try {
-        const newToken = await authApi.refreshToken();
-        localStorage.setItem("token", newToken);
+      const newToken = await refreshNewToken();
+      if (newToken) {
         error.config.headers["Authorization"] = `Bearer ${newToken}`;
         return api(error.config);
-      } catch {
-        localStorage.removeItem("token");
+      } else {
         window.location.href = "/login";
       }
     }

--- a/frontend/src/components/detail/Info/Info.tsx
+++ b/frontend/src/components/detail/Info/Info.tsx
@@ -8,14 +8,13 @@ import { ProductDto } from "../../../types/home/homeProduct";
 import { ReviewDto } from "../../../types/home/review";
 import { fetchProducts, fetchReviews } from "../../../api/home/homeApi";
 import { useNavigate, useLocation } from "react-router-dom";
-import { isLoggedIn, getCurrentMemberId } from "../../../utils/auth";
+import { isLoggedIn, getCurrentMemberId, refreshNewToken } from "../../../utils/auth";
 import {
   addToBasket,
   deleteFromBasket,
   fetchBasketList,
 } from "../../../api/basket/basketApi";
 import { BasketProductDto } from "../../../types/basket/basket";
-
 interface InfoProps {
   travelId: number;
   travel: HomeTravelDto;
@@ -110,9 +109,12 @@ const Info = ({ travelId, travel }: InfoProps) => {
 
   const handleCartClick = async () => {
     if (!isLoggedIn()) {
-      alert("로그인이 필요합니다.");
-      navigate("/login");
-      return;
+      const newToken = await refreshNewToken();
+      if (!newToken) {
+        alert("로그인이 필요합니다.");
+        navigate("/login");
+        return;
+      }
     }
 
     const memberId = getCurrentMemberId();
@@ -168,9 +170,12 @@ const Info = ({ travelId, travel }: InfoProps) => {
 
   const handleReserveClick = async () => {
     if (!isLoggedIn()) {
-      alert("로그인이 필요합니다.");
-      navigate("/login");
-      return;
+      const newToken = await refreshNewToken();
+      if (!newToken) {
+        alert("로그인이 필요합니다.");
+        navigate("/login");
+        return;
+      }
     }
 
     const memberId = getCurrentMemberId();

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,6 +1,8 @@
 // 로그인 상태 확인 유틸리티 함수들
 
 // JWT 토큰 페이로드 타입 정의
+import { authApi } from "../api/login/authApi";
+
 interface TokenPayload {
   memberId: string;
   authId: string;
@@ -22,7 +24,6 @@ export const isLoggedIn = (): boolean => {
   if (decoded.exp) {
     const currentTime = Math.floor(Date.now() / 1000);
     if (currentTime >= decoded.exp) {
-      localStorage.removeItem("token"); // 만료된 토큰 제거
       return false;
     }
   }
@@ -105,4 +106,21 @@ export const getCurrentUserInfo = (): {
     memberId: decoded.memberId,
     authId: decoded.authId,
   };
+};
+
+// 토큰 유효성 체크 후, 필요 시 재발급
+export const refreshNewToken = async (): Promise<string | null> => {
+  const currentUserInfo = getCurrentUserInfo();
+
+  // 사용자 정보가 없는 경우에는 재발급하지 않음
+  if (!currentUserInfo) return null;
+
+  try {
+    const newToken = await authApi.refreshToken();
+    localStorage.setItem("token", newToken);
+    return newToken;
+  } catch {
+    localStorage.removeItem("token");
+    return null;
+  }
 };


### PR DESCRIPTION
## 변경 사항 설명

### 수정 대상
util/auth.ts
isLoggedIn 메서드 사용하는 로직 전부 변경

### 개선 사항
isLoggedIn로 유효성 및 토큰 만료 여부 검사

refreshNewToken 메서드 호출 하여 사용
- 기존에 로그인 하고 있던 사용자면 토큰 재발급
- 로그인 안하고 있던 사용자면 null 리턴

이후 토큰 재발급 여부에 따라 로직 분개 처리
- newToken이 있을 때: 호출만
- newToken이 없을 때: 로그인 화면 이동 또는 alert창 띄워주기 등

## 관련 이슈
#151 

## 체크리스트
- [ ] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)

## 리뷰어를 위한 참고사항