### PR TITLE
fix: 비밀번호 재설정 - 아이디, 이메일 불일치 허용

### DIFF
--- a/backend/src/main/java/solid/backend/main/sign/service/SignServiceImpl.java
+++ b/backend/src/main/java/solid/backend/main/sign/service/SignServiceImpl.java
@@ -137,8 +137,9 @@ public class SignServiceImpl implements SignService {
         Member member = signRepository.findById(signCheckIIdEmailDto.getMemberId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
 
-        member = signRepository.findByMemberEmail(signCheckIIdEmailDto.getMemberEmail())
-                .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+        if (!member.getMemberEmail().equals(signCheckIIdEmailDto.getMemberEmail())) {
+            throw new IllegalArgumentException("아이디와 이메일이 일치하지 않습니다.");
+        }
     }
 
     /**


### PR DESCRIPTION
## 변경 사항 설명
기존 버그
A의 아이디, B의 이메일을 입력해도 두 개의 값이 하나의 사용자라고 인식하여 비밀번호 재설정이 가능함.

아이디를 먼저 조회한 뒤 이메일을 조회

## 관련 이슈
#184 

## 체크리스트
- [ ] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
![스크린샷 2025-07-03 오후 1 22 29](https://github.com/user-attachments/assets/5f10ab55-ed8a-4589-84f5-8864824aa69d)

![스크린샷 2025-07-03 오후 1 22 40](https://github.com/user-attachments/assets/19fef86f-ef27-406b-9ec8-e34309accf20)


## 리뷰어를 위한 참고사항
postman 테스트