### PR TITLE
refactor: 주문내역에서 여행상품 선택시 상세 페이지로 이동 기능 추가

### DIFF
--- a/frontend/src/pages/mypage/orderList/OrderList.tsx
+++ b/frontend/src/pages/mypage/orderList/OrderList.tsx
@@ -15,6 +15,7 @@ import { MypageOrdersListDto } from "../../../types/mypage/order";
 import { useAuth } from "../../../contexts/AuthContext";
 import { getMemberProfile } from "../../../api/mypage/memberApi";
 import { MypageMemberProfileDto } from "../../../types/mypage/member";
+import { useNavigate } from "react-router-dom";
 
 // 주문 상태 텍스트 반환
 const getStatusText = (status: number) => {
@@ -85,6 +86,7 @@ const OrderList = () => {
   const [isEditReview, setIsEditReview] = useState(false);
 
   const memberId = userInfo?.memberId;
+  const navigate = useNavigate();
 
   // 마이페이지 프로필 정보 불러오기
   useEffect(() => {
@@ -304,7 +306,27 @@ const OrderList = () => {
                 </div>
               ) : (
                 orders.map(order => (
-                  <div key={order.orderId} className={styles.orderCard}>
+                  <div key={order.orderId}
+                       className={styles.orderCard}
+                       onClick={() =>
+                         navigate(`/detail/${order.orderTravelId}`, {
+                           state: {
+                             travel: {
+                               travelId: order.orderTravelId,
+                               travelName: order.orderTravelName,
+                               travelStartDt: order.travelStartDt,
+                               travelEndDt: order.travelEndDt,
+                               travelImg: order.travelImg,
+                               travelPrice: order.travelPrice,
+                               travelAmount: order.travelAmount,
+                               reservedCount: order.orderTravelAmount,
+                               travelLabel: order.travelLabel,
+                               travelSold: order.travelSold,
+                             },
+                           },
+                         })
+                       }
+                  >
                     <div className={styles.orderHeader}>
                       <div className={styles.orderInfo}>
                         <span className={styles.orderNumber}>

--- a/frontend/src/types/mypage/order.ts
+++ b/frontend/src/types/mypage/order.ts
@@ -10,6 +10,10 @@ export interface MypageOrdersListDto {
   travelImg: string;
   totalPrice: number;
   reviewCheck: boolean;
+  travelPrice: number;
+  travelLabel : string;
+  travelSold: boolean;
+  travelAmount: number;
   orderProducts: MypageOrdersProductDto[];
 }
 


### PR DESCRIPTION
## 변경 사항 설명
기존에 있던 주문내역 정보 박스에 onClick 메서드 추가

## 관련 이슈
#200 

## 체크리스트
- [x] 코드가 TypeScript/ESLint 규칙을 준수합니다
- [x] 필요한 테스트를 추가했습니다
- [x] 모든 테스트가 통과합니다
- [x] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
x

## 리뷰어를 위한 참고사항
기존에 있던 마이페이지 주문내역 박스 클릭하면 상세 페이지로 화면 이동됨